### PR TITLE
 Start implementation of the Cache. Just load in the lists

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/rec/games/pokemon/teambuilder/MainActivity.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/MainActivity.java
@@ -1,5 +1,6 @@
 package rec.games.pokemon.teambuilder;
 
+import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
@@ -14,6 +15,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements OnPokemonClickListener
@@ -32,25 +34,18 @@ public class MainActivity extends AppCompatActivity implements OnPokemonClickLis
 		final PokemonListAdapter adapter = new PokemonListAdapter(new ArrayList<Pokemon>(), this);
 
 		mViewModel = ViewModelProviders.of(this).get(PokeAPIViewModel.class);
-		mViewModel.getPokeListJSON().observe(this, new Observer<String>()
+		mViewModel.getPokemonCache().observe(this, new Observer<HashMap<Integer, LiveData<Pokemon>>>()
 		{
 			@Override
-			public void onChanged(@Nullable String pokemonListJSON)
+			public void onChanged(@Nullable HashMap<Integer, LiveData<Pokemon>> pokemonCache)
 			{
-				if(pokemonListJSON == null)
+				if(pokemonCache == null)
 				{
-					Log.d(TAG, "Could not load PokemonList JSON");
+					Log.d(TAG, "Could not load PokemonList");
 					return;
 				}
-				Log.d(TAG, "JSON: " + pokemonListJSON);
-				PokeAPIUtils.NamedAPIResourceList apiPokemonList = PokeAPIUtils.parsePokemonListJSON(pokemonListJSON);
-				Log.d(TAG, apiPokemonList.toString());
-				List<Pokemon> pokemon = new ArrayList<>();
-				for(PokeAPIUtils.NamedAPIResource r : apiPokemonList.results)
-				{
-					Pokemon p = new DeferredPokemonResource(PokeAPIUtils.getPokeId(r.url), r.name, r.url);
-					pokemon.add(p);
-				}
+
+				List<Pokemon> pokemon = mViewModel.extractPokemonListFromCache();
 				adapter.updatePokemon(pokemon);
 			}
 		});
@@ -60,16 +55,6 @@ public class MainActivity extends AppCompatActivity implements OnPokemonClickLis
 		rv.setAdapter(adapter);
 		rv.setLayoutManager(new LinearLayoutManager(this));
 		rv.setItemAnimator(new DefaultItemAnimator());
-
-		loadPokemonList();
-	}
-
-	public void loadPokemonList()
-	{
-		String pokemonListURL = PokeAPIUtils.buildPokemonListURL(10000, 0);
-		Log.d(TAG, "URL: " + pokemonListURL);
-
-		mViewModel.loadPokemonListJSON(pokemonListURL);
 	}
 
 	@Override

--- a/app/src/main/java/rec/games/pokemon/teambuilder/MainActivity.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/MainActivity.java
@@ -1,6 +1,5 @@
 package rec.games.pokemon.teambuilder;
 
-import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
@@ -15,7 +14,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements OnPokemonClickListener
@@ -34,18 +32,25 @@ public class MainActivity extends AppCompatActivity implements OnPokemonClickLis
 		final PokemonListAdapter adapter = new PokemonListAdapter(new ArrayList<Pokemon>(), this);
 
 		mViewModel = ViewModelProviders.of(this).get(PokeAPIViewModel.class);
-		mViewModel.getPokemonCache().observe(this, new Observer<HashMap<Integer, LiveData<Pokemon>>>()
+		mViewModel.getPokeListJSON().observe(this, new Observer<String>()
 		{
 			@Override
-			public void onChanged(@Nullable HashMap<Integer, LiveData<Pokemon>> pokemonCache)
+			public void onChanged(@Nullable String pokemonListJSON)
 			{
-				if(pokemonCache == null)
+				if(pokemonListJSON == null)
 				{
-					Log.d(TAG, "Could not load PokemonList");
+					Log.d(TAG, "Could not load PokemonList JSON");
 					return;
 				}
-
-				List<Pokemon> pokemon = mViewModel.extractPokemonListFromCache();
+				Log.d(TAG, "JSON: " + pokemonListJSON);
+				PokeAPIUtils.NamedAPIResourceList apiPokemonList = PokeAPIUtils.parsePokemonListJSON(pokemonListJSON);
+				Log.d(TAG, apiPokemonList.toString());
+				List<Pokemon> pokemon = new ArrayList<>();
+				for(PokeAPIUtils.NamedAPIResource r : apiPokemonList.results)
+				{
+					Pokemon p = new DeferredPokemonResource(PokeAPIUtils.getPokeId(r.url), r.name, r.url);
+					pokemon.add(p);
+				}
 				adapter.updatePokemon(pokemon);
 			}
 		});
@@ -55,6 +60,16 @@ public class MainActivity extends AppCompatActivity implements OnPokemonClickLis
 		rv.setAdapter(adapter);
 		rv.setLayoutManager(new LinearLayoutManager(this));
 		rv.setItemAnimator(new DefaultItemAnimator());
+
+		loadPokemonList();
+	}
+
+	public void loadPokemonList()
+	{
+		String pokemonListURL = PokeAPIUtils.buildPokemonListURL(10000, 0);
+		Log.d(TAG, "URL: " + pokemonListURL);
+
+		mViewModel.loadPokemonListJSON(pokemonListURL);
 	}
 
 	@Override

--- a/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIUtils.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIUtils.java
@@ -10,12 +10,9 @@ import java.io.Serializable;
 public class PokeAPIUtils
 {
 	private final static String POKE_API_BASE_URL = "https://pokeapi.co/api/v2/";
+	private final static String POKE_API_POKEMON_ENDPOINT = "pokemon";
 	private final static String POKE_API_LIMIT_PARAM = "limit";
 	private final static String POKE_API_OFFSET_PARAM = "offset";
-
-	private final static String POKE_API_POKEMON_ENDPOINT = "pokemon";
-	private final static String POKE_API_TYPE_ENDPOINT = "type";
-	private final static String POKE_API_MOVE_ENDPOINT = "move";
 
 	static class NamedAPIResourceList implements Serializable
 	{
@@ -104,30 +101,20 @@ public class PokeAPIUtils
 		return buildNamedAPIResourceListURL(POKE_API_POKEMON_ENDPOINT, limit, offset);
 	}
 
-	static String buildTypeListURL(int limit, int offset)
-	{
-		return buildNamedAPIResourceListURL(POKE_API_TYPE_ENDPOINT, limit, offset);
-	}
-
-	static String buildMoveListURL(int limit, int offset)
-	{
-		return buildNamedAPIResourceListURL(POKE_API_MOVE_ENDPOINT, limit, offset);
-	}
-
-	static NamedAPIResourceList parseNamedAPIResourceListJSON(String namedAPIResourceListJSON)
+	static NamedAPIResourceList parsePokemonListJSON(String pokemonListJSON)
 	{
 		Gson gson = new Gson();
-		return gson.fromJson(namedAPIResourceListJSON, NamedAPIResourceList.class);
+		return gson.fromJson(pokemonListJSON, NamedAPIResourceList.class);
 	}
 
-	static int getId(String url)
+	static int getPokeId(String url)
 	{
 		if(url == null)
 			return 0;
 
-		String id = Uri.parse(url).getLastPathSegment();
-		if(id != null)
-			return Integer.parseInt(id);
+		String pokeId = Uri.parse(url).getLastPathSegment();
+		if(pokeId != null)
+			return Integer.parseInt(pokeId);
 		return 0;
 	}
 }

--- a/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIUtils.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIUtils.java
@@ -10,9 +10,12 @@ import java.io.Serializable;
 public class PokeAPIUtils
 {
 	private final static String POKE_API_BASE_URL = "https://pokeapi.co/api/v2/";
-	private final static String POKE_API_POKEMON_ENDPOINT = "pokemon";
 	private final static String POKE_API_LIMIT_PARAM = "limit";
 	private final static String POKE_API_OFFSET_PARAM = "offset";
+
+	private final static String POKE_API_POKEMON_ENDPOINT = "pokemon";
+	private final static String POKE_API_TYPE_ENDPOINT = "type";
+	private final static String POKE_API_MOVE_ENDPOINT = "move";
 
 	static class NamedAPIResourceList implements Serializable
 	{
@@ -101,20 +104,30 @@ public class PokeAPIUtils
 		return buildNamedAPIResourceListURL(POKE_API_POKEMON_ENDPOINT, limit, offset);
 	}
 
-	static NamedAPIResourceList parsePokemonListJSON(String pokemonListJSON)
+	static String buildTypeListURL(int limit, int offset)
 	{
-		Gson gson = new Gson();
-		return gson.fromJson(pokemonListJSON, NamedAPIResourceList.class);
+		return buildNamedAPIResourceListURL(POKE_API_TYPE_ENDPOINT, limit, offset);
 	}
 
-	static int getPokeId(String url)
+	static String buildMoveListURL(int limit, int offset)
+	{
+		return buildNamedAPIResourceListURL(POKE_API_MOVE_ENDPOINT, limit, offset);
+	}
+
+	static NamedAPIResourceList parseNamedAPIResourceListJSON(String namedAPIResourceListJSON)
+	{
+		Gson gson = new Gson();
+		return gson.fromJson(namedAPIResourceListJSON, NamedAPIResourceList.class);
+	}
+
+	static int getId(String url)
 	{
 		if(url == null)
 			return 0;
 
-		String pokeId = Uri.parse(url).getLastPathSegment();
-		if(pokeId != null)
-			return Integer.parseInt(pokeId);
+		String id = Uri.parse(url).getLastPathSegment();
+		if(id != null)
+			return Integer.parseInt(id);
 		return 0;
 	}
 }

--- a/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIViewModel.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIViewModel.java
@@ -1,10 +1,14 @@
 package rec.games.pokemon.teambuilder;
 
+import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.ViewModel;
-import android.util.Log;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -12,28 +16,26 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.annotations.EverythingIsNonNull;
 
-public class PokeAPIViewModel extends ViewModel
+class PokeAPIViewModel extends ViewModel
 {
-	private MutableLiveData<String> mPokeListJSON = new MutableLiveData<>();
+	private MutableLiveData<HashMap<Integer, LiveData<PokemonType>>> typeCache;
+	private MutableLiveData<HashMap<Integer, LiveData<PokemonMove>>> moveCache;
+	private MutableLiveData<HashMap<Integer, LiveData<Pokemon>>> pokemonCache;
 
-	MutableLiveData<String> getPokeListJSON()
+	PokeAPIViewModel()
 	{
-		return mPokeListJSON;
-	}
+		typeCache = new MutableLiveData<>();
+		moveCache = new MutableLiveData<>();
+		pokemonCache = new MutableLiveData<>();
 
-	void loadPokemonListJSON(String url)
-	{
-		if(url == null || mPokeListJSON == null || mPokeListJSON.getValue() != null)
-			return;
-
-		Log.d(this.getClass().getName(), "fetching JSON from pokeapi");
-		NetworkUtils.doHTTPGet(url, new Callback()
+		//asynchronously load the type list
+		NetworkUtils.doHTTPGet(PokeAPIUtils.buildTypeListURL(10000, 0), new Callback()
 		{
 			@EverythingIsNonNull
 			@Override
 			public void onFailure(Call call, IOException e)
 			{
-				mPokeListJSON.postValue(null);
+				typeCache.postValue(null);
 			}
 
 			@EverythingIsNonNull
@@ -41,9 +43,139 @@ public class PokeAPIViewModel extends ViewModel
 			public void onResponse(Call call, Response response) throws IOException
 			{
 				ResponseBody body = response.body();
-				if(body != null)
-					mPokeListJSON.postValue(body.string());
+				if(body == null)
+				{
+					typeCache.postValue(null);
+					return;
+				}
+
+				//parse the json
+				String typeListJSON = body.string();
+				PokeAPIUtils.NamedAPIResourceList typeList = PokeAPIUtils.parseNamedAPIResourceListJSON(typeListJSON);
+
+				//create a temporary variable, we don't want to post it until we are done processing
+				HashMap<Integer, LiveData<PokemonType>> tempTypeCache = new HashMap<>();
+				for(PokeAPIUtils.NamedAPIResource r: typeList.results)
+				{
+					MutableLiveData<PokemonType> pokemonType = new MutableLiveData<>();
+
+					int id = PokeAPIUtils.getId(r.url);
+					pokemonType.postValue(new DeferredPokemonTypeResource(id, r.name, r.url));
+
+					tempTypeCache.put(id, pokemonType);
+				}
+
+				//now we can finally post the value
+				typeCache.postValue(tempTypeCache);
 			}
 		});
+
+		//asynchronously load the move list
+		NetworkUtils.doHTTPGet(PokeAPIUtils.buildMoveListURL(10000, 0), new Callback()
+		{
+			@EverythingIsNonNull
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				moveCache.postValue(null);
+			}
+
+			@EverythingIsNonNull
+			@Override
+			public void onResponse(Call call, Response response) throws IOException
+			{
+				ResponseBody body = response.body();
+				if(body == null)
+				{
+					moveCache.postValue(null);
+					return;
+				}
+
+				String moveListJSON = body.string();
+				PokeAPIUtils.NamedAPIResourceList moveList = PokeAPIUtils.parseNamedAPIResourceListJSON(moveListJSON);
+
+				HashMap<Integer, LiveData<PokemonMove>> tempMoveCache = new HashMap<>();
+				for(PokeAPIUtils.NamedAPIResource r: moveList.results)
+				{
+					MutableLiveData<PokemonMove> pokemonMove = new MutableLiveData<>();
+
+					int id = PokeAPIUtils.getId(r.url);
+					pokemonMove.postValue(new DeferredPokemonMoveResource(id, r.name, r.url));
+
+					tempMoveCache.put(id, pokemonMove);
+				}
+
+				moveCache.postValue(tempMoveCache);
+			}
+		});
+
+		//asynchronously load the pokemon list
+		NetworkUtils.doHTTPGet(PokeAPIUtils.buildPokemonListURL(10000, 0), new Callback()
+		{
+			@EverythingIsNonNull
+			@Override
+			public void onFailure(Call call, IOException e)
+			{
+				pokemonCache.postValue(null);
+			}
+
+			@EverythingIsNonNull
+			@Override
+			public void onResponse(Call call, Response response) throws IOException
+			{
+				ResponseBody body = response.body();
+				if(body == null)
+				{
+					pokemonCache.postValue(null);
+					return;
+				}
+
+				String pokemonListJSON = body.string();
+				PokeAPIUtils.NamedAPIResourceList pokemonList = PokeAPIUtils.parseNamedAPIResourceListJSON(pokemonListJSON);
+
+				HashMap<Integer, LiveData<Pokemon>> tempPokemonCache = new HashMap<>();
+				for(PokeAPIUtils.NamedAPIResource r: pokemonList.results)
+				{
+					MutableLiveData<Pokemon> pokemon = new MutableLiveData<>();
+
+					int id = PokeAPIUtils.getId(r.url);
+					pokemon.postValue(new DeferredPokemonResource(id, r.name, r.url));
+
+					tempPokemonCache.put(id, pokemon);
+				}
+
+				pokemonCache.postValue(tempPokemonCache);
+			}
+		});
+	}
+
+	LiveData<HashMap<Integer, LiveData<PokemonType>>> getTypeCache()
+	{
+		return typeCache;
+	}
+
+	LiveData<HashMap<Integer, LiveData<PokemonMove>>> getMoveCache()
+	{
+		return moveCache;
+	}
+
+	LiveData<HashMap<Integer, LiveData<Pokemon>>> getPokemonCache()
+	{
+		return pokemonCache;
+	}
+
+	//TODO: later we should refactor away List<Pokemon>, just doing the minimum amount to get the application to compile/run
+	List<Pokemon> extractPokemonListFromCache()
+	{
+		if(pokemonCache.getValue() == null)
+			return null;
+
+		Collection<LiveData<Pokemon>> pokemonReferences = pokemonCache.getValue().values();
+		List<Pokemon> pokemonList = new ArrayList<>(pokemonReferences.size());
+
+		for(LiveData<Pokemon> pokemonReference: pokemonReferences)
+			pokemonList.add(pokemonReference.getValue());
+
+		return pokemonList;
 	}
 }

--- a/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIViewModel.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/PokeAPIViewModel.java
@@ -1,14 +1,10 @@
 package rec.games.pokemon.teambuilder;
 
-import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.ViewModel;
+import android.util.Log;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -16,26 +12,28 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.internal.annotations.EverythingIsNonNull;
 
-class PokeAPIViewModel extends ViewModel
+public class PokeAPIViewModel extends ViewModel
 {
-	private MutableLiveData<HashMap<Integer, LiveData<PokemonType>>> typeCache;
-	private MutableLiveData<HashMap<Integer, LiveData<PokemonMove>>> moveCache;
-	private MutableLiveData<HashMap<Integer, LiveData<Pokemon>>> pokemonCache;
+	private MutableLiveData<String> mPokeListJSON = new MutableLiveData<>();
 
-	PokeAPIViewModel()
+	MutableLiveData<String> getPokeListJSON()
 	{
-		typeCache = new MutableLiveData<>();
-		moveCache = new MutableLiveData<>();
-		pokemonCache = new MutableLiveData<>();
+		return mPokeListJSON;
+	}
 
-		//asynchronously load the type list
-		NetworkUtils.doHTTPGet(PokeAPIUtils.buildTypeListURL(10000, 0), new Callback()
+	void loadPokemonListJSON(String url)
+	{
+		if(url == null || mPokeListJSON == null || mPokeListJSON.getValue() != null)
+			return;
+
+		Log.d(this.getClass().getName(), "fetching JSON from pokeapi");
+		NetworkUtils.doHTTPGet(url, new Callback()
 		{
 			@EverythingIsNonNull
 			@Override
 			public void onFailure(Call call, IOException e)
 			{
-				typeCache.postValue(null);
+				mPokeListJSON.postValue(null);
 			}
 
 			@EverythingIsNonNull
@@ -43,139 +41,9 @@ class PokeAPIViewModel extends ViewModel
 			public void onResponse(Call call, Response response) throws IOException
 			{
 				ResponseBody body = response.body();
-				if(body == null)
-				{
-					typeCache.postValue(null);
-					return;
-				}
-
-				//parse the json
-				String typeListJSON = body.string();
-				PokeAPIUtils.NamedAPIResourceList typeList = PokeAPIUtils.parseNamedAPIResourceListJSON(typeListJSON);
-
-				//create a temporary variable, we don't want to post it until we are done processing
-				HashMap<Integer, LiveData<PokemonType>> tempTypeCache = new HashMap<>();
-				for(PokeAPIUtils.NamedAPIResource r: typeList.results)
-				{
-					MutableLiveData<PokemonType> pokemonType = new MutableLiveData<>();
-
-					int id = PokeAPIUtils.getId(r.url);
-					pokemonType.postValue(new DeferredPokemonTypeResource(id, r.name, r.url));
-
-					tempTypeCache.put(id, pokemonType);
-				}
-
-				//now we can finally post the value
-				typeCache.postValue(tempTypeCache);
+				if(body != null)
+					mPokeListJSON.postValue(body.string());
 			}
 		});
-
-		//asynchronously load the move list
-		NetworkUtils.doHTTPGet(PokeAPIUtils.buildMoveListURL(10000, 0), new Callback()
-		{
-			@EverythingIsNonNull
-			@Override
-			public void onFailure(Call call, IOException e)
-			{
-				moveCache.postValue(null);
-			}
-
-			@EverythingIsNonNull
-			@Override
-			public void onResponse(Call call, Response response) throws IOException
-			{
-				ResponseBody body = response.body();
-				if(body == null)
-				{
-					moveCache.postValue(null);
-					return;
-				}
-
-				String moveListJSON = body.string();
-				PokeAPIUtils.NamedAPIResourceList moveList = PokeAPIUtils.parseNamedAPIResourceListJSON(moveListJSON);
-
-				HashMap<Integer, LiveData<PokemonMove>> tempMoveCache = new HashMap<>();
-				for(PokeAPIUtils.NamedAPIResource r: moveList.results)
-				{
-					MutableLiveData<PokemonMove> pokemonMove = new MutableLiveData<>();
-
-					int id = PokeAPIUtils.getId(r.url);
-					pokemonMove.postValue(new DeferredPokemonMoveResource(id, r.name, r.url));
-
-					tempMoveCache.put(id, pokemonMove);
-				}
-
-				moveCache.postValue(tempMoveCache);
-			}
-		});
-
-		//asynchronously load the pokemon list
-		NetworkUtils.doHTTPGet(PokeAPIUtils.buildPokemonListURL(10000, 0), new Callback()
-		{
-			@EverythingIsNonNull
-			@Override
-			public void onFailure(Call call, IOException e)
-			{
-				pokemonCache.postValue(null);
-			}
-
-			@EverythingIsNonNull
-			@Override
-			public void onResponse(Call call, Response response) throws IOException
-			{
-				ResponseBody body = response.body();
-				if(body == null)
-				{
-					pokemonCache.postValue(null);
-					return;
-				}
-
-				String pokemonListJSON = body.string();
-				PokeAPIUtils.NamedAPIResourceList pokemonList = PokeAPIUtils.parseNamedAPIResourceListJSON(pokemonListJSON);
-
-				HashMap<Integer, LiveData<Pokemon>> tempPokemonCache = new HashMap<>();
-				for(PokeAPIUtils.NamedAPIResource r: pokemonList.results)
-				{
-					MutableLiveData<Pokemon> pokemon = new MutableLiveData<>();
-
-					int id = PokeAPIUtils.getId(r.url);
-					pokemon.postValue(new DeferredPokemonResource(id, r.name, r.url));
-
-					tempPokemonCache.put(id, pokemon);
-				}
-
-				pokemonCache.postValue(tempPokemonCache);
-			}
-		});
-	}
-
-	LiveData<HashMap<Integer, LiveData<PokemonType>>> getTypeCache()
-	{
-		return typeCache;
-	}
-
-	LiveData<HashMap<Integer, LiveData<PokemonMove>>> getMoveCache()
-	{
-		return moveCache;
-	}
-
-	LiveData<HashMap<Integer, LiveData<Pokemon>>> getPokemonCache()
-	{
-		return pokemonCache;
-	}
-
-	//TODO: later we should refactor away List<Pokemon>, just doing the minimum amount to get the application to compile/run
-	List<Pokemon> extractPokemonListFromCache()
-	{
-		if(pokemonCache.getValue() == null)
-			return null;
-
-		Collection<LiveData<Pokemon>> pokemonReferences = pokemonCache.getValue().values();
-		List<Pokemon> pokemonList = new ArrayList<>(pokemonReferences.size());
-
-		for(LiveData<Pokemon> pokemonReference: pokemonReferences)
-			pokemonList.add(pokemonReference.getValue());
-
-		return pokemonList;
 	}
 }


### PR DESCRIPTION
The new change asynchronously loads in the type, move, and pokemon lists into the cache when the ViewModel is instantiated. It also defines the interfaces into the cache. Once I merge in my rate limiting and we refactor our adapter, we should be able to load pokemon in the background