### PR TITLE
Add team view

### DIFF
--- a/app/src/main/java/rec/games/pokemon/teambuilder/Team.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/Team.java
@@ -1,0 +1,8 @@
+package rec.games.pokemon.teambuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Team {
+    List<TeamMember> members = new ArrayList<>();
+}

--- a/app/src/main/java/rec/games/pokemon/teambuilder/TeamAdapter.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/TeamAdapter.java
@@ -1,0 +1,82 @@
+package rec.games.pokemon.teambuilder;
+
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.Observer;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+public class TeamAdapter extends RecyclerView.Adapter<TeamAdapter.ViewHolder> {
+    private LifecycleOwner mLifecycleOwner;
+    private Team team;
+    private Object mListener; // TODO
+
+    public TeamAdapter(LifecycleOwner lifecycleOwner) { mLifecycleOwner = lifecycleOwner; }
+
+    @Override
+    public int getItemCount() {
+        if (team != null && team.members != null) {
+            return team.members.size();
+        }
+        return 0;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int position) {
+        LayoutInflater inf = LayoutInflater.from(parent.getContext());
+        View v = inf.inflate(R.layout.team_list_entry, parent, false);
+        return new ViewHolder(v, mListener, mLifecycleOwner);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder vh, int position) {
+        vh.bind(team.members.get(position));
+    }
+
+    public void setTeam(Team team) {
+        this.team = team;
+        notifyDataSetChanged();
+    }
+
+    public class ViewHolder extends RecyclerView.ViewHolder {
+        private final LifecycleOwner lifecycleOwner;
+        Observer<Pokemon> mObserver;
+        TeamMember mSavedTeamMember;
+        private ImageView image;
+        private TextView name;
+        private Object listener; // TODO
+
+        ViewHolder(View v, Object l, LifecycleOwner lifecycleOwner) {
+            super(v);
+            listener = l;
+            this.lifecycleOwner = lifecycleOwner;
+            image = v.findViewById(R.id.pokemon_sprite);
+            name = v.findViewById(R.id.pokemon_name);
+        }
+
+        void bind(TeamMember member) {
+            if (mObserver != null) {
+                mSavedTeamMember.pokemon.removeObserver(mObserver);
+            }
+            // TODO: set image to ic_poke_unknown
+            name.setText("Loading...");
+            mObserver = new Observer<Pokemon>() {
+                @Override
+                public void onChanged(@Nullable Pokemon pokemon) {
+                    if (pokemon != null) {
+                        name.setText(pokemon.getName());
+                        GlideApp.with(itemView.getContext()).load(PokeAPIUtils.getSpriteUrl(pokemon.getId())).into(image);
+                    }
+                }
+            };
+            member.pokemon.observe(lifecycleOwner, mObserver);
+            mSavedTeamMember = member;
+        }
+    }
+}

--- a/app/src/main/java/rec/games/pokemon/teambuilder/TeamFragment.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/TeamFragment.java
@@ -1,0 +1,33 @@
+package rec.games.pokemon.teambuilder;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+public class TeamFragment extends Fragment {
+    TeamAdapter adapter;
+    RecyclerView teamRV;
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.activity_team, container, false);
+
+        adapter = new TeamAdapter(this);
+        teamRV = view.findViewById(R.id.rv_team_members);
+        teamRV.setAdapter(adapter);
+        teamRV.setLayoutManager(new GridLayoutManager(view.getContext(), 2));
+        teamRV.setItemAnimator(new DefaultItemAnimator());
+
+        return view;
+    }
+
+
+}

--- a/app/src/main/java/rec/games/pokemon/teambuilder/TeamListFragment.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/TeamListFragment.java
@@ -1,30 +1,62 @@
 package rec.games.pokemon.teambuilder;
 
+import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.Observer;
+import android.arch.lifecycle.ViewModelProviders;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-public class TeamListFragment extends Fragment
-{
-	public TeamListFragment()
-	{
+import java.util.HashMap;
 
-	}
+public class TeamListFragment extends Fragment {
+    private Team team;
 
-	@Override
-	public void onCreate(@Nullable Bundle savedInstanceState)
-	{
-		super.onCreate(savedInstanceState);
-	}
+    private TeamAdapter adapter;
+    private RecyclerView teamRV;
 
-	@Nullable
-	@Override
-	public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState)
-	{
-		return inflater.inflate(R.layout.team_list, container, false);
-	}
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.team_list, container, false);
+
+        adapter = new TeamAdapter(this);
+        teamRV = view.findViewById(R.id.rv_team_members);
+        teamRV.setAdapter(adapter);
+        teamRV.setLayoutManager(new GridLayoutManager(view.getContext(), 2));
+        teamRV.setItemAnimator(new DefaultItemAnimator());
+
+        PokeAPIViewModel model = ViewModelProviders.of(this).get(PokeAPIViewModel.class);
+
+        // Fill in with some fake data
+        model.getPokemonCache().observe(this, new Observer<HashMap<Integer, LiveData<Pokemon>>>() {
+            @Override
+            public void onChanged(@Nullable HashMap<Integer, LiveData<Pokemon>> list) {
+                team = new Team();
+
+                team.members.add(newTeamMember(list.get(1))); // Bulbasaur
+                team.members.add(newTeamMember(list.get(133))); // Eevee
+                team.members.add(newTeamMember(list.get(25))); // Pikachu
+                team.members.add(newTeamMember(list.get(150))); // Mewtwo
+                team.members.add(newTeamMember(list.get(404))); // Not Found
+                team.members.add(newTeamMember(list.get(500))); // Internal Server Error
+                adapter.setTeam(team);
+            }
+        });
+
+        return view;
+    }
+
+    private static TeamMember newTeamMember(LiveData<Pokemon> p) {
+        TeamMember tm = new TeamMember();
+        tm.pokemon = p;
+        return tm;
+    }
 }

--- a/app/src/main/java/rec/games/pokemon/teambuilder/TeamMember.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/TeamMember.java
@@ -1,0 +1,7 @@
+package rec.games.pokemon.teambuilder;
+
+import android.arch.lifecycle.LiveData;
+
+public class TeamMember {
+    LiveData<Pokemon> pokemon;
+}

--- a/app/src/main/res/drawable/border.xml
+++ b/app/src/main/res/drawable/border.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white"/>
+    <stroke
+        android:width="2dp"
+        android:color="@android:color/black" />
+    <corners
+        android:topLeftRadius="5dp"
+        android:topRightRadius="5dp"
+        android:bottomLeftRadius="5dp"
+        android:bottomRightRadius="5dp"/>
+</shape>

--- a/app/src/main/res/layout/team_list.xml
+++ b/app/src/main/res/layout/team_list.xml
@@ -11,4 +11,10 @@
         android:layout_gravity="center"
         android:text="Team list"/>
 
+    <android.support.v7.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        android:id="@+id/rv_team_members" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/team_list_entry.xml
+++ b/app/src/main/res/layout/team_list_entry.xml
@@ -1,37 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_margin="10dp">
 
     <LinearLayout
-        android:orientation="vertical"
-        android:gravity="center"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:background="@drawable/border"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:padding="5dp">
 
         <ImageView
+            android:id="@+id/pokemon_sprite"
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:padding="8dp"
-            android:id="@+id/pokemon_sprite"
-            android:src="@drawable/ic_poke_unknown"/>
+            android:src="@drawable/ic_poke_unknown" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/pokemon_name"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                android:textSize="24sp"
-                android:id="@+id/pokemon_name"
-                tools:text="Pokémon"/>
-        </LinearLayout>
+            android:padding="8dp"
+            android:textSize="24sp"
+            tools:text="Pokémon" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/team_list_entry.xml
+++ b/app/src/main/res/layout/team_list_entry.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:gravity="center"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageView
+            android:layout_width="128dp"
+            android:layout_height="128dp"
+            android:padding="8dp"
+            android:id="@+id/pokemon_sprite"
+            android:src="@drawable/ic_poke_unknown"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:textSize="24sp"
+                android:id="@+id/pokemon_name"
+                tools:text="Pokémon"/>
+        </LinearLayout>
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
This adds a viewer for teams. Teams are represented as a list of TeamMembers, with each TeamMember holding a LiveData<Pokemon>. TeamMembers could also store stuff like the moves that a pokemon knows.

The use of a LiveData makes implementing the adapter kind of awkward; maybe we should just use a concrete Pokemon?

```
public class Team {
    List<TeamMember> members = new ArrayList<>();
}
public class TeamMember {
    LiveData<Pokemon> pokemon;
}
```

<img src="https://user-images.githubusercontent.com/175539/53995198-2e4f0900-40e9-11e9-995e-8b544494d3fe.png" height=500>