### PR TITLE
Use static json instead of PokeAPI's servers

### DIFF
--- a/app/src/main/java/rec/games/pokemon/teambuilder/model/PokeAPIUtils.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/model/PokeAPIUtils.java
@@ -10,40 +10,40 @@ public class PokeAPIUtils
 {
 	public static final String POKE_ITEM = "rec.games.pokemon.teambuilder.Model.PokeAPIUtils";
 	private final static String POKE_API_BASE_URL = "https://pokeapi.co/api/v2/";
-	private final static String POKE_API_LIMIT_PARAM = "limit";
-	private final static String POKE_API_OFFSET_PARAM = "offset";
+	private final static String STATIC_POKE_API_BASE_URL = "https://raw.githubusercontent.com/PokeAPI/api-data/master/data/";
 
-	private final static String POKE_API_POKEMON_ENDPOINT = "pokemon";
-	private final static String POKE_API_TYPE_ENDPOINT = "type";
-	private final static String POKE_API_MOVE_ENDPOINT = "move";
+	private final static String POKE_API_POKEMON_ENDPOINT = "api/v2/pokemon";
+	private final static String POKE_API_TYPE_ENDPOINT = "api/v2/type";
+	private final static String POKE_API_MOVE_ENDPOINT = "api/v2/move";
 
 	private final static String POKE_API_SPRITE_URL = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/";
 	private final static String POKE_API_ARTWORK_URL = "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other-sprites/official-artwork/";
-	private final static String POKE_API_SPRITE_FILE_TYPE = ".png";
 
-	static String buildNamedAPIResourceListURL(String endPoint, int limit, int offset)
+	private final static String POKE_API_SPRITE_FILE_TYPE = ".png";
+	private final static String STATIC_POKE_API_FILE_NAME = "index.json";
+
+	static String buildNamedAPIResourceListURL(String endPoint)
 	{
-		return Uri.parse(POKE_API_BASE_URL).buildUpon()
-			.appendPath(endPoint)
-			.appendQueryParameter(POKE_API_LIMIT_PARAM, String.valueOf(limit))
-			.appendQueryParameter(POKE_API_OFFSET_PARAM, String.valueOf(offset))
+		return Uri.parse(STATIC_POKE_API_BASE_URL).buildUpon()
+			.appendEncodedPath(endPoint)
+			.appendPath(STATIC_POKE_API_FILE_NAME)
 			.build()
 			.toString();
 	}
 
-	public static String buildPokemonListURL(int limit, int offset)
+	public static String buildPokemonListURL()
 	{
-		return buildNamedAPIResourceListURL(POKE_API_POKEMON_ENDPOINT, limit, offset);
+		return buildNamedAPIResourceListURL(POKE_API_POKEMON_ENDPOINT);
 	}
 
-	public static String buildTypeListURL(int limit, int offset)
+	public static String buildTypeListURL()
 	{
-		return buildNamedAPIResourceListURL(POKE_API_TYPE_ENDPOINT, limit, offset);
+		return buildNamedAPIResourceListURL(POKE_API_TYPE_ENDPOINT);
 	}
 
-	public static String buildMoveListURL(int limit, int offset)
+	public static String buildMoveListURL()
 	{
-		return buildNamedAPIResourceListURL(POKE_API_MOVE_ENDPOINT, limit, offset);
+		return buildNamedAPIResourceListURL(POKE_API_MOVE_ENDPOINT);
 	}
 
 	public static NamedAPIResourceList parseNamedAPIResourceListJSON(String namedAPIResourceListJSON)
@@ -91,6 +91,16 @@ public class PokeAPIUtils
 	{
 		return Uri.parse(POKE_API_ARTWORK_URL).buildUpon()
 			.appendEncodedPath(Integer.toString(id) + POKE_API_SPRITE_FILE_TYPE).build().toString();
+	}
+
+	public static String fixStaticAPIUrl(String url)
+	{
+		//the url.substring(1) is to avoid "//" from appearing in the url
+		//while that is a valid Uri, don't want to risk a server not processing it correctly
+		return Uri.parse(STATIC_POKE_API_BASE_URL).buildUpon()
+			.appendEncodedPath(url.substring(1))
+			.appendPath(STATIC_POKE_API_FILE_NAME)
+			.toString();
 	}
 
 	public static class NamedAPIResourceList implements Serializable

--- a/app/src/main/java/rec/games/pokemon/teambuilder/model/repository/PokeAPIRepository.java
+++ b/app/src/main/java/rec/games/pokemon/teambuilder/model/repository/PokeAPIRepository.java
@@ -82,7 +82,7 @@ public class PokeAPIRepository
 		final CountDownLatch moveLock = new CountDownLatch(1);
 
 		//asynchronously load the type list
-		NetworkUtils.doPriorityHTTPGet(PokeAPIUtils.buildTypeListURL(10000, 0), NetworkPriority.CRITICAL, new PriorityCallback()
+		NetworkUtils.doPriorityHTTPGet(PokeAPIUtils.buildTypeListURL(), NetworkPriority.CRITICAL, new PriorityCallback()
 		{
 			@Override
 			public boolean onStart()
@@ -118,7 +118,8 @@ public class PokeAPIRepository
 					if(id >= 10000)
 						continue;
 
-					PokemonType pokemonType = new DeferredPokemonTypeResource(id, namedResource.name, namedResource.url);
+					String url = PokeAPIUtils.fixStaticAPIUrl(namedResource.url);
+					PokemonType pokemonType = new DeferredPokemonTypeResource(id, namedResource.name, url);
 
 					updatePokemonType(id, pokemonType);
 				}
@@ -138,7 +139,7 @@ public class PokeAPIRepository
 		});
 
 		//asynchronously load the move list
-		NetworkUtils.doPriorityHTTPGet(PokeAPIUtils.buildMoveListURL(10000, 0), NetworkPriority.CRITICAL, new PriorityCallback()
+		NetworkUtils.doPriorityHTTPGet(PokeAPIUtils.buildMoveListURL(), NetworkPriority.CRITICAL, new PriorityCallback()
 		{
 			@Override
 			public boolean onStart()
@@ -167,10 +168,11 @@ public class PokeAPIRepository
 				String moveListJSON = body.string();
 				PokeAPIUtils.NamedAPIResourceList moveList = PokeAPIUtils.parseNamedAPIResourceListJSON(moveListJSON);
 
-				for(PokeAPIUtils.NamedAPIResource r : moveList.results)
+				for(PokeAPIUtils.NamedAPIResource namedResource : moveList.results)
 				{
-					int id = PokeAPIUtils.getId(r.url);
-					PokemonMove pokemonMove = new DeferredPokemonMoveResource(id, r.name, r.url);
+					int id = PokeAPIUtils.getId(namedResource.url);
+					String url = PokeAPIUtils.fixStaticAPIUrl(namedResource.url);
+					PokemonMove pokemonMove = new DeferredPokemonMoveResource(id, namedResource.name, url);
 
 					updatePokemonMove(id, pokemonMove);
 				}
@@ -197,7 +199,7 @@ public class PokeAPIRepository
 		});
 
 		//asynchronously load the pokemon list
-		NetworkUtils.doPriorityHTTPGet(PokeAPIUtils.buildPokemonListURL(10000, 0), NetworkPriority.CRITICAL, new PriorityCallback()
+		NetworkUtils.doPriorityHTTPGet(PokeAPIUtils.buildPokemonListURL(), NetworkPriority.CRITICAL, new PriorityCallback()
 		{
 			@Override
 			public boolean onStart()
@@ -226,10 +228,11 @@ public class PokeAPIRepository
 				String pokemonListJSON = body.string();
 				PokeAPIUtils.NamedAPIResourceList pokemonList = PokeAPIUtils.parseNamedAPIResourceListJSON(pokemonListJSON);
 
-				for(PokeAPIUtils.NamedAPIResource r : pokemonList.results)
+				for(PokeAPIUtils.NamedAPIResource namedResource : pokemonList.results)
 				{
-					int id = PokeAPIUtils.getId(r.url);
-					Pokemon pokemon = new DeferredPokemonResource(id, r.name, r.url);
+					int id = PokeAPIUtils.getId(namedResource.url);
+					String url = PokeAPIUtils.fixStaticAPIUrl(namedResource.url);
+					Pokemon pokemon = new DeferredPokemonResource(id, namedResource.name, url);
 
 					updatePokemon(id, pokemon);
 				}


### PR DESCRIPTION
This change gets all of the json from their static Github store, rather than their rate limited servers. Tested this and the types, moves, and pokemon still load correctly. With this we can probably up the rate limiter, but I will see how much Github will tolerate the higher limits